### PR TITLE
Paste hotfix 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tpscrollfix
+.idea

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Prevent paste event while it is scrolling with the TrackPoint Keyboard II USB
+
+The TrackPoint lovers would understand the annoying behavior of this keyboard when you want to scroll using the 
+TrackPoint just like any ThinkPad TrackPoint laptop.
+
+## Requirements
+
+- xdotool
+- xinput
+
+## Installation
+
+We need to disable the paste event of the built-in mouse and finally listen its
+events in order to be able triggering the paste event properly
+
+```
+xinput set-button-map 'Lenovo TrackPoint Keyboard II Mouse' 1 10 3 4 5 6 7
+xinput test 'Lenovo TrackPoint Keyboard II Mouse' | tpscrollfix
+```
+
+###Notes
+- You will need to build the binary  **tpscrollfix**
+- You need to move the binary to `/usr/bin` or where you prefer

--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ xinput set-button-map 'Lenovo TrackPoint Keyboard II Mouse' 1 10 3 4 5 6 7
 xinput test 'Lenovo TrackPoint Keyboard II Mouse' | tpscrollfix
 ```
 
-###Notes
+### Notes
 - You will need to build the binary  **tpscrollfix**
 - You need to move the binary to `/usr/bin` or where you prefer


### PR DESCRIPTION
Time to time the paste event was fired while one was scrolling, this hotfix prevent that, and avoid debugging the motion event which is very noise on development time.